### PR TITLE
Allow custom GameScreen header and meter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,6 +71,12 @@ export default function App() {
     setScreen("select");
   }, []);
 
+  const modeSubtitle = useMemo(() => {
+    if (!mode) return undefined;
+    const capitalized = mode[0].toUpperCase() + mode.slice(1);
+    return `${capitalized} Mode`;
+  }, [mode]);
+
   const handleSpin = useCallback(() => {
     if (spinning) return;
 
@@ -130,6 +136,15 @@ export default function App() {
             onSpinDone={handleSpinDone}
             onHelpClick={() => setModalOpen("help")}
             onSettingsClick={() => setModalOpen("settings")}
+            topBar={
+              <TopBar
+                title="Date Night"
+                subtitle={modeSubtitle}
+                onHelp={() => setModalOpen("help")}
+                onSettings={() => setModalOpen("settings")}
+              />
+            }
+            sparkMeter={<SparkMeter value={spark} />}
           />
         )}
       </div>

--- a/src/screens/GameScreen.jsx
+++ b/src/screens/GameScreen.jsx
@@ -4,9 +4,25 @@ import Wheel from "../components/Wheel";
 import SparkMeter from "../components/SparkMeter";
 
 const GameScreen = memo(
-  ({ rotation, onSpin, spinning, spark, onSpinDone, onSettingsClick, onHelpClick }) => (
+  ({
+    rotation,
+    onSpin,
+    spinning,
+    spark,
+    onSpinDone,
+    onSettingsClick,
+    onHelpClick,
+    topBar,
+    sparkMeter,
+  }) => (
     <div className="screen">
-      <TopBar title="Date Night" onSettings={onSettingsClick} onHelp={onHelpClick} />
+      {topBar ?? (
+        <TopBar
+          title="Date Night"
+          onSettings={onSettingsClick}
+          onHelp={onHelpClick}
+        />
+      )}
       <main
         style={{
           display: "grid",
@@ -24,7 +40,7 @@ const GameScreen = memo(
         >
           {spinning ? "Spinning…" : "Spin"}
         </button>
-        <SparkMeter value={spark} />
+        {sparkMeter ?? <SparkMeter value={spark} />}
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary
- derive a contextual subtitle for the game header based on the selected mode
- let the GameScreen accept optional header and meter elements so the parent can supply custom UI
- provide the top bar and spark meter from App with mode-aware subtitle and wiring to modals

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d6e304a40883229030b4bc213416f3