### PR TITLE
Fix runtime luminance helper and complete settings modal

### DIFF
--- a/src/components/components/AvatarSelector.js
+++ b/src/components/components/AvatarSelector.js
@@ -1,0 +1,1 @@
+export { default } from "../AvatarSelector";

--- a/src/components/components/MusicPanel.jsx
+++ b/src/components/components/MusicPanel.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+
+import { MUSIC_TRACK_OPTIONS } from "../../hooks/useMusic";
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const MusicPanel = ({ music }) => {
+  const currentTrackId = music?.currentTrackId ?? MUSIC_TRACK_OPTIONS[0]?.id;
+  const volumePercent = Math.round(clamp((music?.volume ?? 1) * 100, 0, 100));
+  const isMuted = Boolean(music?.isMuted);
+
+  const handleVolumeChange = (event) => {
+    const nextValue = Number(event.target.value);
+    if (Number.isNaN(nextValue)) {
+      return;
+    }
+    music?.setVolume?.(clamp(nextValue, 0, 100) / 100);
+  };
+
+  const handleTrackChange = (event) => {
+    const nextTrackId = event.target.value;
+    if (!nextTrackId) {
+      return;
+    }
+    if (nextTrackId === currentTrackId) {
+      return;
+    }
+    music?.playTrack?.(nextTrackId);
+  };
+
+  const handleMuteToggle = () => {
+    music?.toggleMute?.();
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-white/70">
+        Adjust the background soundtrack for your session. Volume and mute
+        preferences are saved locally and synced across partners when possible.
+      </p>
+      <div className="flex flex-col gap-5">
+        <label className="flex flex-col gap-3">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+            Volume
+          </span>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={volumePercent}
+            onChange={handleVolumeChange}
+            className="accent-[var(--theme-primary)]"
+          />
+          <div className="flex justify-between text-xs text-white/60">
+            <span>Muted</span>
+            <span>{volumePercent}%</span>
+          </div>
+        </label>
+
+        <label className="flex items-center justify-between gap-3">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+            Mute
+          </span>
+          <button
+            type="button"
+            onClick={handleMuteToggle}
+            className={`rounded-full px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] ${
+              isMuted
+                ? "bg-white/20 text-white"
+                : "bg-[var(--theme-primary)] text-black"
+            }`}
+          >
+            {isMuted ? "Muted" : "On"}
+          </button>
+        </label>
+
+        <label className="flex flex-col gap-3">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+            Soundtrack
+          </span>
+          <select
+            value={currentTrackId}
+            onChange={handleTrackChange}
+            className="rounded-xl border border-white/15 bg-black/40 px-4 py-3 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)]"
+          >
+            {MUSIC_TRACK_OPTIONS.map((track) => (
+              <option key={track.id} value={track.id}>
+                {track.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default MusicPanel;

--- a/src/components/components/ThemesPanel.jsx
+++ b/src/components/components/ThemesPanel.jsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from "react";
+
+import { THEMES } from "../../themeConfig";
+
+const toEntries = (themes) => Object.entries(themes ?? {});
+
+const ThemesPanel = ({ themeKey, onThemeChange }) => {
+  const themeEntries = useMemo(() => toEntries(THEMES), []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-white/70">
+        Choose a look and feel for Date Night. Switching themes instantly updates
+        the wheel, interface accents, and ambient effects.
+      </p>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {themeEntries.map(([key, theme]) => {
+          const isActive = key === themeKey;
+          const gradientStart = theme?.bg?.[0] ?? "#111111";
+          const gradientEnd = theme?.bg?.[1] ?? "#222222";
+          const label = theme?.name ?? key;
+
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onThemeChange?.(key)}
+              className={`group flex flex-col gap-3 rounded-2xl border p-4 text-left transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-primary)] ${
+                isActive
+                  ? "border-[var(--theme-primary)] shadow-[0_16px_30px_rgba(0,0,0,0.4)]"
+                  : "border-white/10 hover:border-white/40"
+              }`}
+              style={{
+                background: `linear-gradient(150deg, ${gradientStart}, ${gradientEnd})`,
+              }}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-lg font-semibold text-white">{label}</span>
+                {isActive && (
+                  <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase text-white">
+                    Active
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 text-xs text-white/80">
+                <span className="font-semibold uppercase tracking-[0.3em] text-white/70">
+                  Accents
+                </span>
+                <div className="flex items-center gap-1">
+                  {Object.values(theme?.colors ?? {}).slice(0, 3).map((color) => (
+                    <span
+                      key={color}
+                      className="h-3 w-3 rounded-full"
+                      style={{ backgroundColor: color }}
+                    />
+                  ))}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ThemesPanel;


### PR DESCRIPTION
## Summary
- add a local getLuminance helper in App to prevent runtime errors and wire up profile/music settings
- replace the placeholder settings modal with a tabbed layout for themes, music, avatars, and achievements
- introduce themed Music and Themes panels alongside an AvatarSelector re-export used by the modal

## Testing
- yarn install
- yarn dev

------
https://chatgpt.com/codex/tasks/task_e_68d7121c73548322a40f959f957615ee