### PR TITLE
Create avatar sprite and refactor selector

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,7 +72,7 @@ export default function App() {
   }, [manager]);
   const [profile, setProfile] = useState(() => ({
     ...mockProfile,
-    avatar: mockProfile.avatar ?? "/avatars/avatar_1.svg",
+    avatar: mockProfile.avatar ?? "avatar-bolt",
     themeId: mockProfile.themeId ?? "classic-dark",
   }));
 

--- a/src/assets/avatars.svg
+++ b/src/assets/avatars.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <filter id="glow-cyan" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow-magenta" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <symbol id="avatar-bolt" viewBox="0 0 200 200">
+    <g filter="url(#glow-cyan)" transform="translate(100,100)">
+      <path d="M-10,-50 L-30,10 L0,10 L-20,70 L20,0 L-10,0 L10,-50 Z"
+            fill="#00ffff" stroke="#00ffff" stroke-width="4"/>
+    </g>
+  </symbol>
+
+  <symbol id="avatar-heart" viewBox="0 0 200 200">
+    <g filter="url(#glow-magenta)">
+      <path d="M100 175 C 50 125, 50 75, 100 50 C 150 75, 150 125, 100 175 Z"
+            fill="#ff00ff" stroke="#ff00ff" stroke-width="4"/>
+    </g>
+  </symbol>
+
+  <symbol id="avatar-controller" viewBox="0 0 200 200">
+    <g filter="url(#glow-cyan)" stroke-width="4">
+      <rect x="40" y="80" width="120" height="50" rx="10"
+            fill="#222" stroke="#ffff00"/>
+      <circle cx="70" cy="105" r="15" fill="#333" stroke="#ffff00"/>
+      <circle cx="140" cy="95" r="8" fill="#ff00ff"/>
+      <circle cx="160" cy="115" r="8" fill="#00ffff"/>
+    </g>
+  </symbol>
+
+  <symbol id="avatar-star" viewBox="0 0 200 200">
+    <g filter="url(#glow-magenta)">
+      <path d="M100 25 L125 75 L180 75 L135 110 L150 165 L100 130 L50 165 L65 110 L20 75 L75 75 Z"
+            fill="#ffff00" stroke="#ffff00" stroke-width="3"/>
+    </g>
+  </symbol>
+
+  <symbol id="avatar-note" viewBox="0 0 200 200">
+    <g filter="url(#glow-cyan)" fill="#00ff00" stroke="#00ff00" stroke-width="4">
+      <circle cx="80" cy="150" r="20"/>
+      <rect x="95" y="50" width="10" height="105"/>
+      <path d="M105 50 C 145 50, 145 80, 105 80"/>
+    </g>
+  </symbol>
+
+  <symbol id="avatar-rocket" viewBox="0 0 200 200">
+    <g filter="url(#glow-cyan)" transform="translate(100,100) rotate(-45)">
+      <path d="M0 -70 L20 -20 L20 30 C20 40,-20 40,-20 30 L-20 -20 Z"
+            fill="#ff4500" stroke="#ff4500" stroke-width="4"/>
+      <path d="M0 -70 L-10 -40 L10 -40 Z"
+            fill="#00ffff" stroke="#00ffff" stroke-width="3"/>
+      <path d="M-20 40 L-30 60 L-10 40 Z"
+            fill="#ff4500" stroke="#ff4500" stroke-width="4"/>
+      <path d="M20 40 L30 60 L10 40 Z"
+            fill="#ff4500" stroke="#ff4500" stroke-width="4"/>
+    </g>
+  </symbol>
+
+  <symbol id="avatar-diamond" viewBox="0 0 200 200">
+    <g filter="url(#glow-magenta)" stroke="#33ffff" stroke-width="4">
+      <path d="M100 40 L150 80 L100 160 L50 80 Z" fill="none"/>
+      <path d="M50 80 L150 80"/>
+      <path d="M100 40 L75 80 L100 95 L125 80 Z" fill="none" stroke-width="2"/>
+    </g>
+  </symbol>
+
+  <symbol id="avatar-mask" viewBox="0 0 200 200">
+    <g filter="url(#glow-cyan)" stroke="#ff00ff" stroke-width="4" fill="none" transform="translate(0 20)">
+      <path d="M40 80 C 60 40, 140 40, 160 80 C 150 110, 120 120, 100 120 C 80 120, 50 110, 40 80 Z"/>
+      <circle cx="75" cy="80" r="10"/>
+      <circle cx="125" cy="80" r="10"/>
+    </g>
+  </symbol>
+</svg>

--- a/src/components/AvatarPanel.jsx
+++ b/src/components/AvatarPanel.jsx
@@ -1,27 +1,29 @@
 import React, { useMemo } from "react";
 
-const PRESET_AVATARS = Array.from({ length: 8 }, (_, index) =>
-  `/avatars/avatar_${index + 1}.png`
-);
+import { AvatarGlyph, PRESET_AVATARS } from "./AvatarSelector";
 
-const AvatarPanel = ({ selectedAvatar, onSelect }) => {
-  const avatars = PRESET_AVATARS;
+const AvatarPanel = ({ selectedAvatar, onSelect, avatars = PRESET_AVATARS }) => {
+  const fallbackAvatar = avatars[0]?.id;
+  const displayAvatar = useMemo(() => {
+    if (!selectedAvatar) {
+      return fallbackAvatar;
+    }
 
-  const fallbackAvatar = avatars[0];
-  const displayAvatar = selectedAvatar || fallbackAvatar;
+    return avatars.find((avatar) => avatar.id === selectedAvatar)?.id ?? fallbackAvatar;
+  }, [avatars, fallbackAvatar, selectedAvatar]);
 
   const buttons = useMemo(
     () =>
-      avatars.map((avatarPath) => {
-        const isSelected = selectedAvatar
-          ? selectedAvatar === avatarPath
-          : avatarPath === fallbackAvatar;
+      avatars.map((avatar) => {
+        const isSelected = displayAvatar
+          ? displayAvatar === avatar.id
+          : avatar.id === fallbackAvatar;
 
         return (
           <button
-            key={avatarPath}
+            key={avatar.id}
             type="button"
-            onClick={() => onSelect?.(avatarPath)}
+            onClick={() => onSelect?.(avatar.id)}
             className={`group relative flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-black/40 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
               isSelected
                 ? "scale-105 ring-2 ring-blue-500 shadow-[0_0_20px_rgba(59,130,246,0.75)]"
@@ -29,16 +31,19 @@ const AvatarPanel = ({ selectedAvatar, onSelect }) => {
             }`}
           >
             <span className="absolute inset-0 rounded-full bg-white/5 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-            <img
-              src={avatarPath}
-              alt="Preset avatar"
-              className="relative z-10 h-14 w-14 rounded-full object-cover"
-              draggable={false}
-            />
+            <div className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full">
+              <AvatarGlyph
+                id={avatar.id}
+                label={avatar.label}
+                ariaHidden
+                className="h-14 w-14"
+              />
+            </div>
+            <span className="sr-only">{avatar.label}</span>
           </button>
         );
       }),
-    [avatars, fallbackAvatar, onSelect, selectedAvatar]
+    [avatars, displayAvatar, fallbackAvatar, onSelect]
   );
 
   return (
@@ -49,11 +54,10 @@ const AvatarPanel = ({ selectedAvatar, onSelect }) => {
         </span>
         <div className="relative">
           <div className="h-24 w-24 overflow-hidden rounded-full border-4 border-blue-400 bg-black/40 shadow-[0_0_30px_rgba(59,130,246,0.55)]">
-            <img
-              src={displayAvatar}
-              alt="Selected avatar"
-              className="h-full w-full object-cover"
-              draggable={false}
+            <AvatarGlyph
+              id={displayAvatar}
+              label="Selected avatar"
+              className="h-full w-full"
             />
           </div>
           <div className="pointer-events-none absolute inset-0 rounded-full shadow-[0_0_25px_rgba(59,130,246,0.65)]" />

--- a/src/data/mockProfile.js
+++ b/src/data/mockProfile.js
@@ -1,6 +1,6 @@
 const mockProfile = {
   username: 'Player1',
-  avatar: '/avatars/avatar_1.svg',
+  avatar: 'avatar-bolt',
   achievements: [
     { id: 'first_spin', title: 'Spin Cycle', description: 'Completed your first spin.', unlocked: true, icon: '🌀' },
     { id: 'dare_devil', title: 'Dare Devil', description: 'Completed 5 Dares.', unlocked: true, icon: '🔥' },


### PR DESCRIPTION
## Summary
- add a dedicated SVG sprite that hosts all eight avatar symbols
- refactor AvatarSelector to render <use> icons from the sprite, normalize legacy selections, and persist to localStorage
- update AvatarPanel, mock profile defaults, and app initialization to consume the new avatar identifiers

## Testing
- yarn test *(fails: package doesn't seem to be present in lockfile; install required)*

------
https://chatgpt.com/codex/tasks/task_e_68d7956050fc83228cc5a4d336b82070