### PR TITLE
Fix wheel spin alignment with pointer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,11 @@ import confetti from "canvas-confetti";
 import { AppStyles } from "./styles/AppStyles";
 
 import ParticleCanvas from "./components/ParticleCanvas";
-import Wheel, { SLICE_LABELS, SLICE_CENTERS } from "./components/Wheel";
+import Wheel, {
+  SLICE_LABELS,
+  SLICE_CENTERS,
+  POINTER_ANGLE,
+} from "./components/Wheel";
 import SparkMeter from "./components/SparkMeter";
 import Modal from "./components/Modal";
 import SettingsModal from "./components/SettingsModal";
@@ -215,9 +219,10 @@ export default function App() {
 
     const index = Math.floor(Math.random() * 3);
     const center = SLICE_CENTERS[index];
-    const wantMod = ((360 - center) % 360 + 360) % 360;
+    const pointerTarget =
+      ((POINTER_ANGLE - center) % 360 + 360) % 360;
     const baseMod = ((rotation % 360) + 360) % 360;
-    let extra = wantMod - baseMod;
+    let extra = pointerTarget - baseMod;
     if (extra < 0) extra += 360;
 
     const spins = 4 + Math.floor(Math.random() * 3);

--- a/src/components/Wheel.js
+++ b/src/components/Wheel.js
@@ -1,2 +1,2 @@
 export { default } from "./Wheel.jsx";
-export { SLICE_LABELS, SLICE_CENTERS } from "./Wheel.jsx";
+export { SLICE_LABELS, SLICE_CENTERS, POINTER_ANGLE } from "./Wheel.jsx";

--- a/src/components/Wheel.jsx
+++ b/src/components/Wheel.jsx
@@ -1,7 +1,8 @@
 import React, { useRef, useState, useEffect, useCallback, memo } from "react";
 
 export const SLICE_LABELS = ["Truth", "Dare", "Trivia"];
-export const SLICE_CENTERS = [60, 180, 300];
+export const SLICE_CENTERS = [330, 90, 210];
+export const POINTER_ANGLE = 270;
 
 const Wheel = memo(({ isSpinning, rotation, onDone }) => {
   const wheelEl = useRef(null);


### PR DESCRIPTION
## Summary
- adjust wheel slice centers so labels match the visual sectors
- align spin targeting with the pointer angle so spins stop on the correct result
- expose the pointer angle constant for reuse

## Testing
- yarn install
- yarn build
- CI=1 yarn dev --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d7b723b32883229a4049b92b654148