### PR TITLE
Fix layout import and remove stray return

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import confetti from "canvas-confetti";
 import { AppStyles } from "./styles/AppStyles";
+import "./styles/layout.css";
 
 import ParticleCanvas from "./components/ParticleCanvas";
 import Wheel, {
@@ -153,7 +154,7 @@ export default function App() {
         !nextThemeKey ||
         !Object.prototype.hasOwnProperty.call(THEMES, nextThemeKey)
       ) {
-        return;
+        // removed erroneous return;
       }
       setThemeKey(nextThemeKey);
       setProfile((prev) => ({


### PR DESCRIPTION
## Summary
- add the missing layout stylesheet import to the app entry component
- replace the stray return with a clarifying comment in the theme handler guard

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7ddcf27fc83229cf73a4f08c880c9