### PR TITLE
Remove screen re-export shims

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,9 +15,9 @@ import SettingsModal from "./components/SettingsModal";
 import TopBar from "./components/TopBar";
 
 import SplashScreen from "./components/Screens/SplashScreen";
-import StartScreen from "./components/Screens/StartScreen";
-import ModeSelectionScreen from "./components/Screens/ModeSelectionScreen";
-import GameScreen from "./components/Screens/GameScreen";
+import StartScreen from "./screens/StartScreen.jsx";
+import ModeSelectionScreen from "./screens/ModeSelectionScreen.jsx";
+import GameScreen from "./screens/GameScreen.jsx";
 
 import { THEMES } from "./themeConfig";
 import AudioManager from "./audio/AudioManager";

--- a/src/components/Screens/GameScreen.jsx
+++ b/src/components/Screens/GameScreen.jsx
@@ -1,1 +1,0 @@
-export { default } from "../../screens/GameScreen.jsx";

--- a/src/components/Screens/ModeSelectionScreen.jsx
+++ b/src/components/Screens/ModeSelectionScreen.jsx
@@ -1,1 +1,0 @@
-export { default } from "../../screens/ModeSelectionScreen.jsx";

--- a/src/components/Screens/StartScreen.jsx
+++ b/src/components/Screens/StartScreen.jsx
@@ -1,1 +1,0 @@
-export { default } from "../../screens/StartScreen.jsx";


### PR DESCRIPTION
## Summary
- update App.jsx to import screens directly from src/screens
- remove the redundant re-export shims under src/components/Screens

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80f9496b88322a276f92c540bdb2a