### PR TITLE
Add reduced motion support for wheel animations

### DIFF
--- a/src/styles/Wheel.css
+++ b/src/styles/Wheel.css
@@ -213,3 +213,16 @@
 @media (min-width: 1024px) {
   :root { --wheel-size: min(460px, calc(100vh - 300px)); }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .wheel,
+  .wheel::before,
+  .wheel::after,
+  .wheel-pointer,
+  .wheel-pointer::before,
+  .wheel-pointer::after,
+  .wheel-svg g path {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a prefers-reduced-motion media query to disable wheel animations for motion-sensitive users

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d871e293b88322acfb3780d9350fb1