### PR TITLE
Add fallback wheel background without backdrop filter

### DIFF
--- a/src/styles/Wheel.css
+++ b/src/styles/Wheel.css
@@ -80,6 +80,22 @@
   will-change: transform;
 }
 
+@supports not ((backdrop-filter: blur(16px)) or (-webkit-backdrop-filter: blur(16px))) {
+  .wheel {
+    background:
+      radial-gradient(circle at center, rgba(255, 255, 255, 0.15), transparent 60%),
+      conic-gradient(
+        from -90deg,
+        var(--truth) 0deg,
+        var(--truth) 120deg,
+        var(--dare) 120deg,
+        var(--dare) 240deg,
+        var(--trivia) 240deg,
+        var(--trivia) 360deg
+      );
+  }
+}
+
 .wheel::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- add a @supports rule to preserve the wheel gradient when backdrop-filter is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d872b2cbd883228c709be86e818b9a