### PR TITLE
Center start screen content

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body,
+#root {
+  height: 100%;
+}
+
+.start-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+  z-index: 1;
+  position: relative;
+}
+
 canvas.particles {
   position: fixed;
   inset: 0;

--- a/src/screens/StartScreen.jsx
+++ b/src/screens/StartScreen.jsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 
 const StartScreen = memo(({ onPickMode }) => (
-  <div>
+  <div className="start-screen">
     <div
       className="glass"
       style={{


### PR DESCRIPTION
## Summary
- wrap the start screen UI in a dedicated container for consistent centering
- add global height and start-screen styles so the layout centers while preserving the particle backdrop

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d87ab648a48322844ce603d248106e