### PR TITLE
Add start screen styling to AppStyles

### DIFF
--- a/src/styles/AppStyles.js
+++ b/src/styles/AppStyles.js
@@ -54,4 +54,116 @@ export const AppStyles = `
     box-shadow: 0 0 45px 5px color-mix(in srgb, var(--ring) 60%, transparent);
   }
 }
+
+/* --- Start Screen Styles --- */
+/* --- Start Screen Container & Background --- */
+.start-screen-container {
+  display: grid;
+  place-content: center;
+  min-height: 100vh; /* Use 100dvh in production for best mobile results */
+  padding: 1rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.start-screen-container::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(80vw, 600px);
+  height: min(80vw, 600px);
+  background: radial-gradient(circle, var(--glow-color, #ff477e50) 0%, transparent 70%);
+  filter: blur(100px);
+  opacity: 0.5;
+  z-index: -1;
+}
+
+/* --- Glassmorphism Card --- */
+.glass-card {
+  width: min(92vw, 520px);
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  border-radius: 1.75rem;
+  text-align: center;
+  background: var(--bg-overlay, rgba(20, 20, 30, 0.6));
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-strong, rgba(0, 0, 0, 0.5) 0px 10px 40px);
+}
+
+/* --- Typography --- */
+.brand-title {
+  font-size: clamp(2.8rem, 10vw, 3.5rem);
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+  color: var(--label-color, #fff);
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 20px var(--glow-color, #fff);
+}
+
+.subtitle {
+  font-size: clamp(1rem, 4vw, 1.125rem);
+  opacity: 0.9;
+  margin: 0 0 2.5rem;
+  color: var(--label-color, #fff);
+}
+
+/* --- Buttons --- */
+.button-group {
+  display: grid;
+  gap: 1rem;
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 52px;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.85rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--label-color, #fff);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  will-change: transform, box-shadow;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+}
+
+.btn:hover {
+  transform: scale(1.03) translateY(-3px);
+  box-shadow: 0 8px 30px color-mix(in srgb, var(--glow-color, #fff) 50%, transparent);
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+/* Theme-aware button gradients */
+.grad-truth { background: linear-gradient(45deg, var(--truth-color), color-mix(in srgb, var(--truth-color) 70%, var(--ring-strong))); }
+.grad-dare { background: linear-gradient(45deg, var(--dare-color), color-mix(in srgb, var(--dare-color) 70%, var(--consequence-color))); }
+.grad-trivia { background: linear-gradient(45deg, var(--trivia-color), color-mix(in srgb, var(--trivia-color) 70%, var(--ring-faint))); }
+
+/* --- Entry Animations --- */
+@keyframes slide-in-fade {
+  from { opacity: 0; transform: translateY(20px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.animate-in {
+  animation: slide-in-fade 0.7s cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+.delay-1 { animation-delay: 0.1s; }
+.delay-2 { animation-delay: 0.2s; }
+.delay-3 { animation-delay: 0.3s; }
+.delay-4 { animation-delay: 0.4s; }
+.delay-5 { animation-delay: 0.5s; }
 `;


### PR DESCRIPTION
## Summary
- add dedicated start screen styling to the global AppStyles template
- include layout, glass card, button, and animation rules for new start screen experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87cdef2dc83229772f24b0730e4b9