### PR TITLE
Remove duplicate TopBar styling

### DIFF
--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -11,10 +11,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1rem;
+  width: 100%;
+  padding: calc(0.75rem + var(--safe-area-top)) clamp(1rem, 5vw, 1.5rem) 0.75rem;
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 100;
 
   background: var(--bar-bg);
   backdrop-filter: blur(16px);
@@ -76,7 +77,7 @@
 
 @media (max-width: 600px) {
   .top-bar {
-    padding: 0.65rem 0.85rem;
+    padding: calc(0.65rem + var(--safe-area-top)) clamp(0.85rem, 6vw, 1.2rem) 0.65rem;
     gap: 0.5rem;
   }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -23,28 +23,3 @@ body, #root {
   transition: background 0.5s ease;
 }
 
-/* Top Bar */
-.top-bar {
-  padding: calc(0.75rem + var(--safe-area-top)) clamp(1rem, 5vw, 1.5rem) 0.75rem;
-  width: 100%;
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-.top-bar__inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 1200px;
-  margin: 0 auto;
-}
-
-.top-bar__title {
-  margin: 0;
-  font-family: 'Baloo 2', sans-serif;
-  font-size: clamp(1.5rem, 3vw, 2.25rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  text-shadow: 0 2px 5px rgba(0,0,0,0.2);
-}


### PR DESCRIPTION
## Summary
- consolidate TopBar spacing, safe-area padding, and sticky stacking into `src/components/TopBar.css`
- remove obsolete TopBar selectors from `src/styles/layout.css` so the component is the sole source of its styles

## Testing
- yarn test *(fails: workspace package missing from lockfile in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d890db169483229ffeada59fd16f95