### PR TITLE
Render SparkMeter samples in the main app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -265,6 +265,10 @@ export default function App() {
     <div className={`animated-background ${screenFlash ? "screen-flash-active" : ""}`}>
       <style>{AppStyles}</style>
       <ParticleCanvas theme={particleTheme} />
+      <SparkMeter value={65} theme="truth" />
+      <SparkMeter value={85} theme="dare" />
+      <SparkMeter value={45} theme="trivia" />
+      <SparkMeter value={100} theme="consequence" />
 
       <div className={`screen ${screen === "splash" ? "enter" : ""}`}>
         {screen === "splash" && <SplashScreen />}


### PR DESCRIPTION
## Summary
- render sample SparkMeter components in the main App output so the widget appears with multiple themes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d89703e7048322876ddb7fb20d1eb4