### PR TITLE
Wrap SparkMeter demos in section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -265,10 +265,14 @@ export default function App() {
     <div className={`animated-background ${screenFlash ? "screen-flash-active" : ""}`}>
       <style>{AppStyles}</style>
       <ParticleCanvas theme={particleTheme} />
-      <SparkMeter value={65} theme="truth" />
-      <SparkMeter value={85} theme="dare" />
-      <SparkMeter value={45} theme="trivia" />
-      <SparkMeter value={100} theme="consequence" />
+      {/* The SparkMeters are now containerized in a styled section */}
+      <section className="spark-section" aria-labelledby="spark-section-heading">
+        <h2 id="spark-section-heading">Spark Meter Showcase</h2>
+        <SparkMeter value={65} theme="truth" />
+        <SparkMeter value={85} theme="dare" />
+        <SparkMeter value={45} theme="trivia" />
+        <SparkMeter value={100} theme="consequence" />
+      </section>
 
       <div className={`screen ${screen === "splash" ? "enter" : ""}`}>
         {screen === "splash" && <SplashScreen />}


### PR DESCRIPTION
## Summary
- wrap the existing SparkMeter demos in a dedicated section with heading and accessible labeling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89913442c8322be751e472f7f45bb