### PR TITLE
Add animation and interactivity to spark section

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -67,3 +67,61 @@ body, #root {
   }
 }
 
+
+/* --- 1. Section Entrance Animation --- */
+
+/* Defines the keyframes for the fade-in and upward slide effect */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Applies the entrance animation to the section.
+  'forwards' ensures it stays in the final state after playing once. */
+.spark-section {
+  animation: fadeInUp 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+---
+
+/* --- 2. SparkMeter Item Interactivity --- */
+
+/* Smooth transitions for hover/focus effects */
+.spark-section .spark-meter {
+  border-radius: 1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  will-change: transform, box-shadow;
+}
+
+/* Hover/focus-visible states */
+.spark-section .spark-meter:hover,
+.spark-section .spark-meter:focus-visible {
+  transform: scale(1.03);
+  box-shadow: 0 0 25px -5px var(--glow-color, rgba(142, 197, 252, 0.5));
+  outline: none;
+}
+
+---
+
+/* --- 3. Accessibility for Reduced Motion --- */
+@media (prefers-reduced-motion: reduce) {
+  .spark-section {
+    animation: none;
+  }
+
+  .spark-section .spark-meter {
+    transition: none;
+  }
+
+  .spark-section .spark-meter:hover,
+  .spark-section .spark-meter:focus-visible {
+    transform: none;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a fade-in entrance animation for the spark section container
- introduce hover and focus styles for spark meter items
- ensure reduced motion users receive static presentation of the section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89aa8bfa88322afa7c402184496b2